### PR TITLE
Defect: Wrong number in about_basics

### DIFF
--- a/src/about_basics.c
+++ b/src/about_basics.c
@@ -78,7 +78,7 @@ Test(about_basics, variables)
         "A number literal starting with 0x will be interpreted as hexadecimal");
     cr_expect_eq(ll, 0b11111111,
         "A number literal starting with 0b will be interpreted as binary");
-    cr_assert_eq(ll, 0777,
+    cr_assert_eq(ll, 0377,
         "A number literal starting with 0 will be interpreted as octal");
 
     double d = 3.50;


### PR DESCRIPTION
The suggested example, 0xFF (255), in octal is equivalent to 0377, *not* 0777.

0377 = 255 = 0xFF
0777 = 511 = 0x1FF