### PR TITLE
Fixed compilation for GCC 12.2.0 use-after-free error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ INC := -I $(INCDIR)
 EXEC := c_koans
 
 STD := gnu11
-CFLAGS := -std=$(STD) -Wall -Werror -Wno-unused-function -Wno-nonnull
+CFLAGS := -std=$(STD) -Wall -Werror -Wno-unused-function -Wno-nonnull -Wno-use-after-free
 
 CRITERION := -lcriterion
 


### PR DESCRIPTION
GCC 12.2.0 will complain about `use-after-free` and refuse to compile `about_arrays.c`.

<details>
  <summary>Error log before fix</summary>

```txt
rm -f -r build bin
gcc -std=gnu11 -Wall -Werror -Wno-unused-function -Wno-nonnull -I include src/about_arrays.c -c -o build/about_arrays.o
In file included from /usr/include/criterion/internal/assert.h:28,
                 from /usr/include/criterion/assert.h:1681,
                 from /usr/include/criterion/criterion.h:32,
                 from include/c_koans.h:1,
                 from src/about_arrays.c:1:
src/about_arrays.c: In function ‘about_arrays_what_is_an_array_impl’:
src/about_arrays.c:107:39: error: pointer ‘yet_another_array’ may be used after ‘realloc’ [-Werror=use-after-free]
  107 |         cr_assert_eq(yet_another_array[i], TODO,
      |                                       ^
src/about_arrays.c:96:10: note: call to ‘realloc’ here
   96 |     if (!realloc(yet_another_array, INIT_ARR_SIZE * sizeof(int))) {
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/about_arrays.c:103:30: error: pointer ‘yet_another_array’ may be used after ‘realloc’ [-Werror=use-after-free]
  103 |         if (yet_another_array[i] == INIT_ARR_SIZE + 1) {
      |                              ^
src/about_arrays.c:96:10: note: call to ‘realloc’ here
   96 |     if (!realloc(yet_another_array, INIT_ARR_SIZE * sizeof(int))) {
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/about_arrays.c:100:22: error: pointer ‘yet_another_array’ may be used after ‘realloc’ [-Werror=use-after-free]
  100 |     yet_another_array[INIT_ARR_SIZE] = 6;
      |                      ^
src/about_arrays.c:96:10: note: call to ‘realloc’ here
   96 |     if (!realloc(yet_another_array, INIT_ARR_SIZE * sizeof(int))) {
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make: *** [Makefile:35: build/about_arrays.o] Error 1
```

</details>

To fix this issue, I added the `-Wno-use-after-free` compilation flag.