### PR TITLE
fix: realloc may return new address

### DIFF
--- a/.github/workflows/c_koans.yml
+++ b/.github/workflows/c_koans.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - run: sudo add-apt-repository -y ppa:snaipewastaken/ppa
-
       - run: sudo apt-get update -qqq
 
       - run: sudo apt-get install -yqq criterion-dev

--- a/.github/workflows/c_koans.yml
+++ b/.github/workflows/c_koans.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/c_koans.yml
+++ b/.github/workflows/c_koans.yml
@@ -15,6 +15,6 @@ jobs:
 
       - run: sudo apt-get update -qqq
 
-      - run: sudo apt-get install -yqq criterion-dev
+      - run: sudo apt-get install -yqq libcriterion-dev
 
       - run: make clean all

--- a/src/about_arrays.c
+++ b/src/about_arrays.c
@@ -92,8 +92,9 @@ Test(about_arrays, what_is_an_array)
 
     /*
         When we need to, we can make an array bigger to accommodate via realloc.
+        The address may change so we always reassign the pointer.
     */
-    if (!realloc(yet_another_array, INIT_ARR_SIZE * sizeof(int))) {
+    if (!(yet_another_array = realloc(yet_another_array, INIT_ARR_SIZE * sizeof(int)))) {
         exit(1);
     }
 

--- a/src/about_arrays.c
+++ b/src/about_arrays.c
@@ -31,7 +31,7 @@ Test(about_arrays, what_is_an_array)
     /*
      * An array variable's name is merely a label for the address of the first
      * element in the array.
-    */
+     */
     cr_assert_eq(*array, TODO,
         "Dereferencing this label's address gives us the "
         "value at that point");
@@ -94,7 +94,8 @@ Test(about_arrays, what_is_an_array)
         When we need to, we can make an array bigger to accommodate via realloc.
         The address may change so we always reassign the pointer.
     */
-    if (!(yet_another_array = realloc(yet_another_array, INIT_ARR_SIZE * sizeof(int)))) {
+    if (!(yet_another_array
+            = realloc(yet_another_array, INIT_ARR_SIZE * sizeof(int)))) {
         exit(1);
     }
 


### PR DESCRIPTION
Starting in GCC 12 the compiler warns how realloc may return a new address and we didn't update the pointer to capture the return value. 

Now we do!

Fixes #15 and #13